### PR TITLE
Reference install command from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ cmake --build .
 
 Executable file *msk144decoder* will appear at the current directory.
 
+To install the binaries for system-wide use, you can additionally run the following command:
+
+```shell
+sudo cmake --install .
+```
+
+(`sudo` can be omitted if run as root)
+
 Wav-file reading example:
 ```shell
 cat ../demo/000000_000001.wav | ./msk144decoder


### PR DESCRIPTION
As the title says. The reason behind this is that users over on our end (OpenWebRX) will follow through with the steps described on the readme, but without doing the `install` step, OpenWebRX is unable to locate the binary, and as such won't make the mode available. This should help those users.

Also, I saw that you have some examples that use the `csdr` tool. I have recently made some structural changes to my version of csdr that would result in some updated command lines. Let me know if you're interested in reworking those examples with the new syntax.